### PR TITLE
Facility store 생성

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,6 @@ import KakaoMap from 'components/KakaoMap';
 function Home() {
   return (
     <div>
-      Home
       <KakaoMap></KakaoMap>
     </div>
   );

--- a/src/store/useFacilityStore.ts
+++ b/src/store/useFacilityStore.ts
@@ -1,9 +1,16 @@
+import { Facility } from 'types';
 import { create } from 'zustand';
 
 interface FacilityState {
-  facilities: any[];
+  facilities: Facility[];
+  selectedFacility: Facility | null;
 }
 
-const useFacilityStore = create<FacilityState>()((set) => ({
+export const useFacilityStore = create<FacilityState>()((set) => ({
   facilities: [],
+  selectedFacility: null,
+
+  setFacilities: (data: Facility[]) => set(() => ({ facilities: data })),
+  setSelectedFacility: (data: Facility) =>
+    set(() => ({ selectedFacility: data })),
 }));

--- a/src/store/useFacilityStore.ts
+++ b/src/store/useFacilityStore.ts
@@ -1,16 +1,31 @@
 import { Facility } from 'types';
 import { create } from 'zustand';
 
-interface FacilityState {
+/**
+ * facilities: 맵에 표시될 장소 목록
+ * selectedFacility: 맵 또는 목록에서 선택된 장소
+ */
+type FacilityState = {
   facilities: Facility[];
   selectedFacility: Facility | null;
-}
+};
 
-export const useFacilityStore = create<FacilityState>()((set) => ({
-  facilities: [],
-  selectedFacility: null,
+/**
+ * setFacilities: 장소 검색 api 호출 후 업데이트
+ * setSelectedFacility: 맵 마커 클릭 or 목록 클릭 시 업데이트
+ */
+type FacilityAction = {
+  setFacilities: (facilities: Facility[]) => void;
+  setSelectedFacility: (facility: Facility) => void;
+};
 
-  setFacilities: (data: Facility[]) => set(() => ({ facilities: data })),
-  setSelectedFacility: (data: Facility) =>
-    set(() => ({ selectedFacility: data })),
-}));
+export const useFacilityStore = create<FacilityState & FacilityAction>()(
+  (set) => ({
+    facilities: [],
+    selectedFacility: null,
+
+    setFacilities: (facilities) => set(() => ({ facilities })),
+    setSelectedFacility: (selectedFacility) =>
+      set(() => ({ selectedFacility })),
+  })
+);


### PR DESCRIPTION
지도에 장소를 띄우기 위해서 전역 상태 관리가 필요합니다.
상태관리 라이브러리 [zustand](https://zustand.docs.pmnd.rs/getting-started/introduction)를 사용했습니다.

